### PR TITLE
After refresh, set axios.headers and getCurrentUser again

### DIFF
--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -42,6 +42,10 @@ export default class ApiService {
     return this._send(uri, 'delete', query)
   }
 
+  setHeaders(token){
+    axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
+  }
+
   _send(uri = '', method, data) {
     let params = {}
 

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -13,6 +13,10 @@ export default class AuthService {
     return this.api.post('session', data)
   }
 
+  setAxiosAuthHeaders(token) {
+    this.api.setHeaders(token) 
+  }
+
   resetPassword(data) {
     return this.api.post('password-reset', data)
   }

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -1,6 +1,5 @@
 import router from '@/router.js'
 import AuthService from '@/services/auth.service.js'
-import axios from 'axios'
 
 const authService = new AuthService()
 
@@ -12,12 +11,13 @@ export const state = {
 }
 
 export const mutations = {
-  AUTHENTICATE_USER(state, payload) {
-    state.apiToken = payload
+  AUTHENTICATE_USER(state, token) {
+    state.apiToken = token
     state.signedIn = true
     router.push({ name: 'home'})
-
+    localStorage.setItem('token', token)
   },
+
   CLEAR_AUTH_DATA(state) {
     state.apiToken = null
     state.signedIn = false
@@ -31,19 +31,9 @@ export const actions = {
     authService.login(payload)
       .then(response => {
         const token = response.data.data
-
+        authService.setAxiosAuthHeaders(token)
         commit('AUTHENTICATE_USER', token)
-
-        //det er her jeg skal sætte vores currentUser i vores user module til den user som er logget ind
-
-        
-        axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
-
         dispatch('user/fetchCurrentUser', null, {root: true})
-
-        localStorage.setItem('token', token)
-        localStorage.setItem('user', '5caf58cbdae9733668b9881c')
-        // router.go(1)
       })
       .catch(error => {
         throw error
@@ -56,12 +46,14 @@ export const actions = {
     localStorage.removeItem('user')
   },
 
-  tryAutoLogin({ commit }) {
+  tryAutoLogin({ commit, dispatch }) {
     const token = localStorage.getItem('token')
     if (!token) {
       return
     }
+    authService.setAxiosAuthHeaders(token)
     commit('AUTHENTICATE_USER', token)
+    dispatch('user/fetchCurrentUser', null, {root: true})
   }
 }
 

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -11,8 +11,10 @@ export const state = {
 
 export const mutations = {
   SET_CURRENT_USER(state, currentUser) {
-    // console.log(state, currentUser)
     state.currentUser = currentUser
+    
+    // Needs changing to currentUSers real id
+    localStorage.setItem('user', '5caf58cbdae9733668b9881c')
   },
 
   SET_USERS(state, users){


### PR DESCRIPTION
Set the current user in vuex state again after browser refresh.  Code is not DRY in auth.js module where auth, commit and dispatch repeats in both login() action and tryAutoLogin() action. Would be nice with some ideas on refactoring? 